### PR TITLE
INTERLOK-3555 #comment Update the pom url to point to the right doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Checking out interlok configuration from git on startup.
 
 ## Canonical Reference Documentation
 
-[https://interlok.adaptris.net/interlok-docs/advanced-vcs-git.html](https://interlok.adaptris.net/interlok-docs/advanced-vcs-git.html)
+[https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-vcs-git](https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-vcs-git)
 
 ## Quickstart
 

--- a/build.gradle
+++ b/build.gradle
@@ -273,7 +273,7 @@ publishing {
         properties.appendNode("target", "3.8.0+")
         properties.appendNode("tags", "git,vcs")
         properties.appendNode("license", "false")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/advanced-vcs-git.html")
+        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-vcs-git")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-vcs-git")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-vcs-git/raw/develop/README.md")
       }

--- a/build.gradle
+++ b/build.gradle
@@ -269,11 +269,11 @@ publishing {
       pom.withXml {
         asNode().appendNode("description", "Checking config out of GIT on startup")
         asNode().appendNode("name", componentName)
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-vcs-git")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.8.0+")
         properties.appendNode("tags", "git,vcs")
         properties.appendNode("license", "false")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-vcs-git")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-vcs-git")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-vcs-git/raw/develop/README.md")
       }


### PR DESCRIPTION
## Motivation
The documentation was broken since we changed the doc site

## Modification
Fix the doc url

## Result
The pom has a correct doc url

## Testing
Check that the new url exists in the POM file after running gradle generatePomFileForMavenJavaPublication.