### PR TITLE
Updated to latest JGit 6.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,6 @@ ext.hasGraphViz = { ->
   }
 }
 
-task getDeps(type: Copy) {
-  from sourceSets.main.runtimeClasspath
-  into 'runtime/'
-}
-
 ext.gitBranchNameOrTimestamp = { branchName ->
   if (branchName.equals("HEAD") || branchName.equals("develop") || branchName.startsWith("release")) {
     return new Date().format('HH:mm:ss z');

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ ext {
   organizationUrl = "http://interlok.adaptris.net"
   slf4jVersion = '2.0.9'
   mockitoVersion = '5.2.0'
-  jgitVersion = '5.13.2.202306221912-r'
+  jgitVersion = '6.7.0.202309050840-r'
 }
 
 // If graphviz is installed via scoop, plantuml doesn't find it because it's not
@@ -42,6 +42,11 @@ ext.hasGraphViz = { ->
   return System.getenv("GRAPHVIZ_DOT") !=null ||  System.getenv("PATH").split(File.pathSeparator).any{
     java.nio.file.Paths.get("${it}").resolve(app).toFile().exists()
   }
+}
+
+task getDeps(type: Copy) {
+  from sourceSets.main.runtimeClasspath
+  into 'runtime/'
 }
 
 ext.gitBranchNameOrTimestamp = { branchName ->

--- a/src/main/java/com/adaptris/vcs/git/auth/AuthenticationProviderImpl.java
+++ b/src/main/java/com/adaptris/vcs/git/auth/AuthenticationProviderImpl.java
@@ -9,8 +9,8 @@ import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 import java.util.Properties;
 
 import org.eclipse.jgit.api.TransportConfigCallback;
-import org.eclipse.jgit.transport.JschConfigSessionFactory;
-import org.eclipse.jgit.transport.OpenSshConfig.Host;
+import org.eclipse.jgit.transport.ssh.jsch.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.ssh.jsch.OpenSshConfig.Host;
 import org.eclipse.jgit.transport.SshTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
## Motivation

JGit has security vulnerabilities, so we need to upgrade to the latest,

## Modification

Changes are minimal between 5.x and 6.x; appears to only be package changes.

## Result

interlok-vcs-git is now up to date.
